### PR TITLE
Implement PPI::Element::next_sibling()

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -1,7 +1,29 @@
+#define PERL_NO_GET_CONTEXT
+
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
 #include "ppport.h"
+
+/* Big enough to store UINT64_MAX in ASCII. */
+#define UINT64_STR_MAX 20
+
+/* PPI::Element::_PARENT */
+HV *_PARENT;
+
+/* Pointer value to ASCII. */
+char *
+ptoa(char *buf, PTRV p)
+{
+    char *c = buf + UINT64_STR_MAX + 1;
+
+    do {
+        *--c = '0' + (p % 10);
+        p /= 10;
+    } while (p);
+
+    return c;
+}
 
 MODULE = PPI::XS	PACKAGE = PPI::XS
 
@@ -38,3 +60,42 @@ PPCODE:
 {
     XSRETURN_NO;
 }
+
+SV *
+_PPI_Element__next_sibling (self)
+    SV *    self
+PPCODE:
+{
+    PTRV key = (PTRV)SvRV(self);
+
+    char key_buf[UINT64_STR_MAX];
+
+    char *key_str = ptoa(key_buf, key);
+
+    I32 key_str_len = UINT64_STR_MAX - (key_str - key_buf) + 1;
+
+    SV **parent_ptr = hv_common(_PARENT, NULL, key_str, key_str_len, 0, HV_FETCH_JUST_SV, NULL, 0);
+
+    if (parent_ptr) {
+        HV *parent = (HV *)SvRV(*parent_ptr);
+
+        SV **children_ptr = hv_common(parent, NULL, "children", 8, 0, HV_FETCH_JUST_SV, NULL, 0);
+
+        AV *children = (AV *)SvRV(*children_ptr);
+
+        SV **ary = AvARRAY(children);
+        SSize_t top = av_tindex(children);
+
+        Size_t i;
+        for (i = 0; i < top; i++)
+            if (key == (PTRV)SvRV(ary[i])) {
+                ST(0) = ary[i + 1];
+                XSRETURN(1);
+            }
+    }
+
+    XSRETURN_NO;
+}
+
+BOOT:
+    _PARENT = get_hv("PPI::Element::_PARENT", 0);

--- a/bench
+++ b/bench
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+bench='../perl/Porting/bench.pl'
+
+if [ ! -e $bench ]; then
+    echo "Can't find bench.pl"
+    exit 1;
+fi
+
+make
+
+perl=`which perl`
+
+$bench -w /tmp/bench --perlargs='-I. -Mbench=1' $perl=pp
+$bench -r /tmp/bench --perlargs='-I. -Mbench=0' $perl=xs
+
+rm /tmp/bench

--- a/bench.pm
+++ b/bench.pm
@@ -1,0 +1,11 @@
+package bench;
+
+use blib;
+
+sub import {
+    $PPI::XS_DISABLE = $_[1];
+
+    require PPI::XS;
+}
+
+1;

--- a/t/perf/benchmarks
+++ b/t/perf/benchmarks
@@ -1,0 +1,17 @@
+[
+    next_sibling => {
+        desc  => '',
+        setup => '$e = ($d = PPI::Document->new(\q($foo + $bar)))->{children}[0]{children}[0]',
+        code  => '$e->next_sibling',
+    },
+    next_sibling_no_parent => {
+        desc  => '',
+        setup => '$e = PPI::Document->new(\q($foo))',
+        code  => '$e->next_sibling',
+    },
+    next_sibling_no_siblings => {
+        desc  => '',
+        setup => '$e = ($d = PPI::Document->new(\q($foo)))->{children}[0]{children}[0]',
+        code  => '$e->next_sibling',
+    },
+];


### PR DESCRIPTION
This commit implements PPI::Element::next_sibling() in XS and adds
some infrastructure for benchmarking the PPI and XS versions with
the bench.pl in perl.git that leverages Cachegrind to get accurate
reproducible meassurements.

Running ./bench with the commit produces the following on my PC:

```
Key:
    Ir   Instruction read
    Dr   Data read
    Dw   Data write
    COND conditional branches
    IND  indirect branches
    _m   branch predict miss
    _m1  level 1 cache miss
    _mm  last cache (e.g. L3) miss
    -    indeterminate percentage (e.g. 1/0)

The numbers represent relative counts per loop iteration, compared to
pp at 100.0%.
Higher is better: for example, using half as many instructions gives 200%,
while using twice as many gives 50%.

next_sibling

           pp      xs
       ------ -------
    Ir 100.00  818.07
    Dr 100.00  975.82
    Dw 100.00 1179.29
  COND 100.00  984.87
   IND 100.00  884.62

COND_m 100.00 1660.98
 IND_m 100.00 1720.00

 Ir_m1 100.00       -
 Dr_m1 100.00       -
 Dw_m1 100.00       -

 Ir_mm 100.00  100.00
 Dr_mm 100.00  100.00
 Dw_mm 100.00  100.00

next_sibling_no_parent

           pp      xs
       ------ -------
    Ir 100.00  261.57
    Dr 100.00  295.47
    Dw 100.00  322.43
  COND 100.00  293.46
   IND 100.00  344.44

COND_m 100.00       -
 IND_m 100.00  500.00

 Ir_m1 100.00  100.00
 Dr_m1 100.00  100.00
 Dw_m1 100.00  100.00

 Ir_mm 100.00  100.00
 Dr_mm 100.00  100.00
 Dw_mm 100.00  100.00

next_sibling_no_siblings

           pp      xs
       ------ -------
    Ir 100.00  757.59
    Dr 100.00  911.52
    Dw 100.00 1077.14
  COND 100.00  921.48
   IND 100.00  853.85

COND_m 100.00 3152.63
 IND_m 100.00 1660.00

 Ir_m1 100.00       -
 Dr_m1 100.00       -
 Dw_m1 100.00       -

 Ir_mm 100.00  100.00
 Dr_mm 100.00  100.00
 Dw_mm 100.00  100.00

AVERAGE

           pp      xs
       ------ -------
    Ir 100.00  471.30
    Dr 100.00  544.84
    Dw 100.00  615.03
  COND 100.00  544.64
   IND 100.00  576.39

COND_m 100.00 2175.68
 IND_m 100.00  942.27

 Ir_m1 100.00  100.00
 Dr_m1 100.00  100.00
 Dw_m1 100.00  100.00

 Ir_mm 100.00  100.00
 Dr_mm 100.00  100.00
 Dw_mm 100.00  100.00
```